### PR TITLE
Fixed potential error in getSettings

### DIFF
--- a/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
+++ b/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
@@ -88,7 +88,11 @@ class GoogleRecaptcha extends Captcha
         $settings = parent::getSettings();
         $config = Craft::$app->getConfig()->getConfigFromFile('sprout-forms-google-recaptcha');
 
-        return array_merge($settings, $config);
+        if ($settings) {
+            return array_merge($settings, $config);
+        }
+
+        return $config;
     }
 
     /**


### PR DESCRIPTION
It's possible for `/<cpTrigger>/sprout-forms/settings/spam-protection` to error with

```
array_merge(): Argument #1 is not an array
1. in /Users/home/Sites/viget/viget.com/vendor/barrelstrength/sprout-forms-google-recaptcha/src/integrations/sproutforms/captchas/GoogleRecaptcha.php
at line 92
```

This happens (at least. I didn't dig deep) if `$settings` is `NULL`. Fix is to only merge `$settings` if there are settings to merge.

Saw other places in this file where a single function has multiple possible `return` points so wrote this like that. Happy to refactor.